### PR TITLE
对应nacos当前稳定版本 nacos-server-2.2.3.zip

### DIFF
--- a/nacos-spring-boot-example/nacos-spring-boot-discovery-example/pom.xml
+++ b/nacos-spring-boot-example/nacos-spring-boot-discovery-example/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>nacos-spring-boot-discovery-example</artifactId>
 
     <properties>
-        <nacos-discovery-spring-boot.version>0.2.1</nacos-discovery-spring-boot.version>
+        <nacos-discovery-spring-boot.version>0.2.7</nacos-discovery-spring-boot.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
nacos-discovery-spring-boot-starter 需要由0.2.1升级到0.2.7 否则这个案例无法获取到服务列表  https://github.com/nacos-group/nacos-examples/tree/master/nacos-spring-boot-example/nacos-spring-boot-discovery-example

debug也发现如下现象：
    @NacosInjected
    private NamingService namingService;
nacos-discovery-spring-boot-starter  0.2.1 版本 namingService使用的namespace是default
nacos-discovery-spring-boot-starter  0.2.7 版本 namingService使用的namespace是public
如果是使用最新的稳定版本 nacos-server-2.2.3.zip 默认的namespace也是 public

结论：
如果使用nacos-server-2.2.3.zip，需要对应使用nacos-discovery-spring-boot-starter  0.2.7。
如果一定需要用nacos-discovery-spring-boot-starter  0.2.1，则需要找下对应的nacos-server的版本